### PR TITLE
HBASE-23015 Update to be jdk7+ compat so we can use the shaded-gson in branch-1.

### DIFF
--- a/hbase-shaded-miscellaneous/pom.xml
+++ b/hbase-shaded-miscellaneous/pom.xml
@@ -32,7 +32,7 @@
   <parent>
     <groupId>org.apache.hbase.thirdparty</groupId>
     <artifactId>hbase-thirdparty</artifactId>
-    <version>2.2.2-SNAPSHOT</version>
+    <version>2.3.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>hbase-shaded-miscellaneous</artifactId>
@@ -128,7 +128,8 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>27.1-jre</version>
+      <!-- we use the "-android" version instead of "-jre" because that version is jdk7 compatible -->
+      <version>28.1-android</version>
       <exclusions>
         <exclusion>
           <groupId>com.google.code.findbugs</groupId>
@@ -179,7 +180,8 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-collections4</artifactId>
-      <version>4.3</version>
+      <!-- Commons collections 4.2 was the latest to support jdk7 -->
+      <version>4.2</version>
     </dependency>
     <dependency>
       <groupId>com.google.errorprone</groupId>

--- a/hbase-shaded-netty/pom.xml
+++ b/hbase-shaded-netty/pom.xml
@@ -32,7 +32,7 @@
   <parent>
     <groupId>org.apache.hbase.thirdparty</groupId>
     <artifactId>hbase-thirdparty</artifactId>
-    <version>2.2.2-SNAPSHOT</version>
+    <version>2.3.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>hbase-shaded-netty</artifactId>

--- a/hbase-shaded-protobuf/pom.xml
+++ b/hbase-shaded-protobuf/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.hbase.thirdparty</groupId>
     <artifactId>hbase-thirdparty</artifactId>
-    <version>2.2.2-SNAPSHOT</version>
+    <version>2.3.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>hbase-shaded-protobuf</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
   </parent>
   <groupId>org.apache.hbase.thirdparty</groupId>
   <artifactId>hbase-thirdparty</artifactId>
-  <version>2.2.2-SNAPSHOT</version>
+  <version>2.3.0-SNAPSHOT</version>
   <name>Apache HBase Third-Party Libs</name>
   <packaging>pom</packaging>
   <description>
@@ -122,7 +122,7 @@
       yyyy-MM-dd'T'HH:mm
     </maven.build.timestamp.format>
     <buildDate>${maven.build.timestamp}</buildDate>
-    <compileSource>1.8</compileSource>
+    <compileSource>1.7</compileSource>
     <java.min.version>${compileSource}</java.min.version>
     <maven.min.version>3.3.3</maven.min.version>
     <rename.offset>org.apache.hbase.thirdparty</rename.offset>


### PR DESCRIPTION
* set jdk constraints in maven to jdk7
* switch Guava to the -android modifier since it is jdk7 compat
* update Guava while we're at it.
* downgrade commons-collection4 to the last jdk7 compat version
* up version to next minor release, since we added support for jdk7 and changed two minor versions


This is a WIP for discussion. DO NOT MERGE.

Please see discussion on [HBASE-23052](https://issues.apache.org/jira/browse/HBASE-23052)