### PR TITLE
HBASE-23052 Provide a jdk7 compatible relocated GSON in its own module.

### DIFF
--- a/hbase-shaded-gson/pom.xml
+++ b/hbase-shaded-gson/pom.xml
@@ -35,12 +35,15 @@
     <version>3.0.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
-  <artifactId>hbase-shaded-miscellaneous</artifactId>
-  <name>Apache HBase Relocated (Shaded) Third-party Miscellaneous Libs</name>
+  <artifactId>hbase-shaded-gson</artifactId>
+  <name>Apache HBase Relocated (Shaded) GSON Libs</name>
   <description>
-    Pulls down a set of libs, relocates them and then makes a fat new jar with them all in it.
-    See below for what this miscellaney includes.
+    Pulls down GSON, relocates it and makes a far jar.
   </description>
+  <properties>
+    <!-- This GSON is also used by branch-1, so make sure we're jdk7 compatible -->
+    <compileSource>1.7</compileSource>
+  </properties>
   <build>
     <plugins>
       <plugin>
@@ -70,24 +73,12 @@
               <createSourcesJar>true</createSourcesJar>
               <relocations>
                 <relocation>
-                  <pattern>com.google.common</pattern>
-                  <shadedPattern>${rename.offset}.com.google.common</shadedPattern>
-                </relocation>
-                <relocation>
                   <pattern>com.google.gson</pattern>
                   <shadedPattern>${rename.offset}.com.google.gson</shadedPattern>
                 </relocation>
                 <relocation>
-                  <pattern>com.google.protobuf</pattern>
-                  <shadedPattern>${rename.offset}.com.google.protobuf</shadedPattern>
-                </relocation>
-                <relocation>
                   <pattern>com.google.thirdparty</pattern>
                   <shadedPattern>${rename.offset}.com.google.thirdparty</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>org.apache.commons</pattern>
-                  <shadedPattern>${rename.offset}.org.apache.commons</shadedPattern>
                 </relocation>
               </relocations>
               <artifactSet>
@@ -104,7 +95,6 @@
                   <exclude>com.google.errorprone:error_prone_annotations</exclude>
                   <exclude>com.google.j2objc:j2objc-annotations</exclude>
                   <exclude>org.codehaus.mojo:animal-sniffer-annotations</exclude>
-                  <exclude>com.google.code.gson:gson</exclude>
                 </excludes>
               </artifactSet>
               <transformers>
@@ -122,65 +112,9 @@
   </build>
   <dependencies>
     <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>27.1-jre</version>
-      <exclusions>
-        <exclusion>
-          <groupId>com.google.code.findbugs</groupId>
-          <artifactId>jsr305</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.google.errorprone</groupId>
-          <artifactId>error_prone_annotations</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.google.j2objc</groupId>
-          <artifactId>j2objc-annotations</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>animal-sniffer-annotations</artifactId>
-        </exclusion>
-        <!-- Just an empty jar-->
-        <exclusion>
-          <groupId>com.google.guava</groupId>
-          <artifactId>listenablefuture</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.checkerframework</groupId>
-          <artifactId>checker-qual</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>com.google.protobuf</groupId>
-      <artifactId>protobuf-java-util</artifactId>
-      <!--Version should be same as protobuf in adjacent module
-           except sometimes they publish new protobuf version w/o
-           updating util.-->
-      <version>${protobuf.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>com.google.protobuf</groupId>
-          <artifactId>protobuf-java</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>commons-cli</groupId>
-      <artifactId>commons-cli</artifactId>
-      <version>1.4</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-collections4</artifactId>
-      <version>4.3</version>
-    </dependency>
-    <dependency>
-      <groupId>com.google.errorprone</groupId>
-      <artifactId>error_prone_annotations</artifactId>
-      <version>2.3.3</version>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+      <version>2.8.5</version>
     </dependency>
   </dependencies>
 </project>

--- a/hbase-shaded-netty/pom.xml
+++ b/hbase-shaded-netty/pom.xml
@@ -32,7 +32,7 @@
   <parent>
     <groupId>org.apache.hbase.thirdparty</groupId>
     <artifactId>hbase-thirdparty</artifactId>
-    <version>2.2.2-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>hbase-shaded-netty</artifactId>

--- a/hbase-shaded-protobuf/pom.xml
+++ b/hbase-shaded-protobuf/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.hbase.thirdparty</groupId>
     <artifactId>hbase-thirdparty</artifactId>
-    <version>2.2.2-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>hbase-shaded-protobuf</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
   </parent>
   <groupId>org.apache.hbase.thirdparty</groupId>
   <artifactId>hbase-thirdparty</artifactId>
-  <version>2.2.2-SNAPSHOT</version>
+  <version>3.0.0-SNAPSHOT</version>
   <name>Apache HBase Third-Party Libs</name>
   <packaging>pom</packaging>
   <description>
@@ -56,6 +56,7 @@
   <modules>
     <module>hbase-shaded-protobuf</module>
     <module>hbase-shaded-netty</module>
+    <module>hbase-shaded-gson</module>
     <module>hbase-shaded-miscellaneous</module>
   </modules>
   <scm>


### PR DESCRIPTION
* pulls gson into its own module
* made just that module require jdk7
* no dependency version changes
* updates version to 3.0.0-SNAP since we have to change which artifact we depend on for gson

tested locally by building, inspecting jars, and trying to use with branch-1 with HBASE-23015 PR.

further discussion on [HBASE-23052](https://issues.apache.org/jira/browse/HBASE-23052)