### PR TITLE
HBASE-23052 add a jdk7-compt miscellaneous module for use on branch-1

### DIFF
--- a/hbase-shaded-miscellaneous-jdk7/pom.xml
+++ b/hbase-shaded-miscellaneous-jdk7/pom.xml
@@ -35,11 +35,17 @@
     <version>2.3.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
-  <artifactId>hbase-shaded-netty</artifactId>
-  <name>Apache HBase Relocated (Shaded) Netty Libs</name>
+  <artifactId>hbase-shaded-miscellaneous</artifactId>
+  <version>${project.parent.version}-jdk7</version>
+  <name>Apache HBase Relocated (Shaded) Third-party Miscellaneous Libs for JDK7+</name>
   <description>
-    Pulls down netty.io, relocates nd then makes a fat new jar with them all in it.
+    Pulls down a set of libs, relocates them and then makes a fat new jar with them all in it.
+    See below for what this miscellaney includes.
   </description>
+  <properties>
+    <!-- These dependencies get used on branches-1, so they need to be jdk7 compat  -->
+    <compileSource>1.7</compileSource>
+  </properties>
   <build>
     <plugins>
       <plugin>
@@ -69,69 +75,50 @@
               <createSourcesJar>true</createSourcesJar>
               <relocations>
                 <relocation>
-                  <pattern>io.netty</pattern>
-                  <shadedPattern>${rename.offset}.io.netty</shadedPattern>
+                  <pattern>com.google.common</pattern>
+                  <shadedPattern>${rename.offset}.com.google.common</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>com.google.gson</pattern>
+                  <shadedPattern>${rename.offset}.com.google.gson</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>com.google.protobuf</pattern>
+                  <shadedPattern>${rename.offset}.com.google.protobuf</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>com.google.thirdparty</pattern>
+                  <shadedPattern>${rename.offset}.com.google.thirdparty</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.apache.commons</pattern>
+                  <shadedPattern>${rename.offset}.org.apache.commons</shadedPattern>
                 </relocation>
               </relocations>
               <artifactSet>
                 <excludes>
                   <!--Exclude protobuf itself. We get a patched version in adjacent module.
                         Exclude other dependencies of guava, netty, etc.
+
+                      Anything added here needs to be excluded from the jar that pulls it in
+                      also else we give an odd signal in the META-INF/DEPENDENCIES that we
+                      produce. See below for how to exclusion of transitive dependencies.
                     -->
                   <exclude>com.google.protobuf:protobuf-java</exclude>
                   <exclude>com.google.code.findbugs:jsr305</exclude>
                   <exclude>com.google.errorprone:error_prone_annotations</exclude>
                   <exclude>com.google.j2objc:j2objc-annotations</exclude>
                   <exclude>org.codehaus.mojo:animal-sniffer-annotations</exclude>
-                  <exclude>org.codehaus.mojo:animal-sniffer-annotations</exclude>
                 </excludes>
               </artifactSet>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer">
+                </transformer>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer">
+                  <addHeader>false</addHeader>
+                </transformer>
+              </transformers>
             </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <!--This trick from
-             https://stackoverflow.com/questions/33825743/rename-files-inside-a-jar-using-some-maven-plugin
-
-            The netty jar has a .so in it. Shading requires rename of the .so and then passing a system
-            property so netty finds the renamed .so and associates it w/ the relocated netty files.
-
-            Add this define when running unit tests:
-            
-               mvn test -Dorg.apache.hbase.thirdparty.io.netty.packagePrefix=org.apache.hbase.thirdparty. -Dtest=TestNettyIPC
-
-            See toward the end of this issue for how to pass config:
-            
-              https://github.com/netty/netty/issues/6665
-
-            TODO: Ensure native works.
-            NOTE: The 'tofile' in the move command below has the relocation hard-coded
-            with '-' instead of '.' separators. If change the relocation, need to change here too.
-          -->
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-antrun-plugin</artifactId>
-        <version>1.8</version>
-        <executions>
-          <execution>
-            <id>unpack</id>
-            <phase>package</phase>
-            <configuration>
-              <target>
-                <echo message="unjar"/>
-                <unzip src="${project.build.directory}/${project.artifactId}-${project.version}.jar"
-                  dest="${project.build.directory}/unpacked/"/>
-                <echo message="Rename netty .so in META-INF"/>
-                <move file="${project.build.directory}/unpacked/META-INF/native/libnetty_transport_native_epoll_x86_64.so"
-                  tofile="${project.build.directory}/unpacked/META-INF/native/liborg_apache_hbase_thirdparty_netty_transport_native_epoll_x86_64.so" />
-                <echo message="Redo jar"/>
-                <jar destfile="${project.build.directory}/${project.artifactId}-${project.version}.jar"
-                    basedir="${project.build.directory}/unpacked"/>
-              </target>
-            </configuration>
-            <goals>
-              <goal>run</goal>
-            </goals>
           </execution>
         </executions>
       </plugin>
@@ -139,9 +126,9 @@
   </build>
   <dependencies>
     <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-all</artifactId>
-      <version>4.1.34.Final</version>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+      <version>${hbase.thirdparty.gson.version}</version>
     </dependency>
   </dependencies>
 </project>

--- a/hbase-shaded-miscellaneous/pom.xml
+++ b/hbase-shaded-miscellaneous/pom.xml
@@ -32,7 +32,7 @@
   <parent>
     <groupId>org.apache.hbase.thirdparty</groupId>
     <artifactId>hbase-thirdparty</artifactId>
-    <version>2.2.2-SNAPSHOT</version>
+    <version>2.3.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>hbase-shaded-miscellaneous</artifactId>
@@ -123,7 +123,7 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.8.5</version>
+      <version>${hbase.thirdparty.gson.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>

--- a/hbase-shaded-protobuf/pom.xml
+++ b/hbase-shaded-protobuf/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.hbase.thirdparty</groupId>
     <artifactId>hbase-thirdparty</artifactId>
-    <version>2.2.2-SNAPSHOT</version>
+    <version>2.3.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>hbase-shaded-protobuf</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
   </parent>
   <groupId>org.apache.hbase.thirdparty</groupId>
   <artifactId>hbase-thirdparty</artifactId>
-  <version>2.2.2-SNAPSHOT</version>
+  <version>2.3.0-SNAPSHOT</version>
   <name>Apache HBase Third-Party Libs</name>
   <packaging>pom</packaging>
   <description>
@@ -57,6 +57,7 @@
     <module>hbase-shaded-protobuf</module>
     <module>hbase-shaded-netty</module>
     <module>hbase-shaded-miscellaneous</module>
+    <module>hbase-shaded-miscellaneous-jdk7</module>
   </modules>
   <scm>
     <connection>scm:git:git://git.apache.org/hbase-thirdparty.git</connection>
@@ -117,6 +118,7 @@
   <developers/>
   <!--TODO-->
   <properties>
+    <hbase.thirdparty.gson.version>2.8.5</hbase.thirdparty.gson.version>
     <maven.javadoc.skip>true</maven.javadoc.skip>
     <maven.build.timestamp.format>
       yyyy-MM-dd'T'HH:mm


### PR DESCRIPTION
* makes a new module for jdk7 compatible miscellaneous dependencies
* jdk7 version of miscellaneous has same coordinates as `hbase-shaded-miscellaneous` but with a jdk7-specific version number. should help maven keep from including both within a given downstream project
* starts with just gson in the jdk7 misc module, starts both with the same gson version
* no dependencies change version
* updates version to next minor release since there's a new module

This is a WIP for discussion. DO NOT MERGE.

Please see discussion on [HBASE-23052](https://issues.apache.org/jira/browse/HBASE-23052)