### PR TITLE
HBASE-23790: Bump netty version to 4.1.45.Final in hbase-thirdparty

### DIFF
--- a/hbase-shaded-miscellaneous/pom.xml
+++ b/hbase-shaded-miscellaneous/pom.xml
@@ -124,7 +124,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>28.2-jre</version>
+      <version>${guava.version}</version>
       <exclusions>
         <exclusion>
           <groupId>com.google.code.findbugs</groupId>
@@ -174,17 +174,17 @@
     <dependency>
       <groupId>commons-cli</groupId>
       <artifactId>commons-cli</artifactId>
-      <version>1.4</version>
+      <version>${commons-cli.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-collections4</artifactId>
-      <version>4.4</version>
+      <version>${commons-collections.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.errorprone</groupId>
       <artifactId>error_prone_annotations</artifactId>
-      <version>2.3.4</version>
+      <version>${error_prone_annotations.version}</version>
     </dependency>
   </dependencies>
 </project>

--- a/hbase-shaded-netty/pom.xml
+++ b/hbase-shaded-netty/pom.xml
@@ -138,7 +138,7 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-all</artifactId>
-      <version>4.1.44.Final</version>
+      <version>${netty.version}</version>
     </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -128,6 +128,11 @@
     <maven.min.version>3.3.3</maven.min.version>
     <rename.offset>org.apache.hbase.thirdparty</rename.offset>
     <protobuf.version>3.11.1</protobuf.version>
+    <netty.version>4.1.45.Final</netty.version>
+    <guava.version>28.2-jre</guava.version>
+    <commons-cli.version>1.4</commons-cli.version>
+    <commons-collections.version>4.4</commons-collections.version>
+    <error_prone_annotations.version>2.3.4</error_prone_annotations.version>
   </properties>
   <build>
     <pluginManagement>


### PR DESCRIPTION
Updated netty version to 4.1.45.Final
Collected dependency version numbers into main pom.xml