### PR TITLE
HBASE-23811. [OpenTracing] Add shaded JaegerTracing tracer to hbase-thirdparty.

### DIFF
--- a/hbase-shaded-gson/pom.xml
+++ b/hbase-shaded-gson/pom.xml
@@ -32,7 +32,7 @@
   <parent>
     <groupId>org.apache.hbase.thirdparty</groupId>
     <artifactId>hbase-thirdparty</artifactId>
-    <version>3.2.1-SNAPSHOT</version>
+    <version>3.3.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>hbase-shaded-gson</artifactId>

--- a/hbase-shaded-jaeger/pom.xml
+++ b/hbase-shaded-jaeger/pom.xml
@@ -74,14 +74,16 @@
                                         <exclude>javax.annotation:javax.annotation-api</exclude> <!-- comes in through JDK -->
                                         <exclude>org.slf4j:slf4j-api</exclude>                   <!-- hbase-common has it too -->
                                         <exclude>io.opentracing:*</exclude>                      <!-- hbase-common declares this dependency too -->
+                                        <exclude>com.google.code.gson:gson</exclude>             <!-- exclude it because hbase-shaded-misc jar has it -->
                                     </excludes>
                                 </artifactSet>
 
                                 <relocations>
-                                    <!-- shade gson, which is transitively included via jaeger-core -->
+                                    <!-- gson is transitively included via jaeger-core -->
+                                    <!-- the gson classes are excluded from the shaded jar. Update the reference to use the gson in hbase-shaded-misc jar -->
                                     <relocation>
                                         <pattern>com.google.gson</pattern>
-                                        <shadedPattern>${rename.offset}.io.jaegertracing.com.google.gson</shadedPattern>
+                                        <shadedPattern>${rename.offset}.com.google.gson</shadedPattern>
                                     </relocation>
 
                                     <!-- shade jaeger-thrift and its dependencies -->

--- a/hbase-shaded-jaeger/pom.xml
+++ b/hbase-shaded-jaeger/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <artifactId>hbase-thirdparty</artifactId>
         <groupId>org.apache.hbase.thirdparty</groupId>
-        <version>3.2.1-SNAPSHOT</version>
+        <version>3.3.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>hbase-shaded-jaeger</artifactId>
@@ -67,13 +67,13 @@
 
                                 <artifactSet>
                                     <excludes>
-                                        <exclude>org.apache.httpcomponents:httpclient</exclude>
-                                        <exclude>commons-logging:commons-logging</exclude>
-                                        <exclude>commons-codec:commons-codec</exclude>
-                                        <exclude>org.apache.httpcomponents:httpcore</exclude>
-                                        <exclude>javax.annotation:javax.annotation-api</exclude>
-                                        <exclude>org.slf4j:slf4j-api</exclude>
-                                        <exclude>io.opentracing:*</exclude>
+                                        <exclude>org.apache.httpcomponents:httpclient</exclude>  <!-- hadoop-common has it too -->
+                                        <exclude>commons-logging:commons-logging</exclude>       <!-- transitively added by hbase-common -> commons-validator -->
+                                        <exclude>commons-codec:commons-codec</exclude>           <!-- hbase-common has it too -->
+                                        <exclude>org.apache.httpcomponents:httpcore</exclude>    <!-- hbase-common has it too -->
+                                        <exclude>javax.annotation:javax.annotation-api</exclude> <!-- comes in through JDK -->
+                                        <exclude>org.slf4j:slf4j-api</exclude>                   <!-- hbase-common has it too -->
+                                        <exclude>io.opentracing:*</exclude>                      <!-- hbase-common declares this dependency too -->
                                     </excludes>
                                 </artifactSet>
 

--- a/hbase-shaded-jaeger/pom.xml
+++ b/hbase-shaded-jaeger/pom.xml
@@ -1,0 +1,176 @@
+<?xml version="1.0"?>
+<project xmlns="https://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <!--
+  /**
+   * Licensed to the Apache Software Foundation (ASF) under one
+   * or more contributor license agreements.  See the NOTICE file
+   * distributed with this work for additional information
+   * regarding copyright ownership.  The ASF licenses this file
+   * to you under the Apache License, Version 2.0 (the
+   * "License"); you may not use this file except in compliance
+   * with the License.  You may obtain a copy of the License at
+   *
+   *     http://www.apache.org/licenses/LICENSE-2.0
+   *
+   * Unless required by applicable law or agreed to in writing, software
+   * distributed under the License is distributed on an "AS IS" BASIS,
+   * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   * See the License for the specific language governing permissions and
+   * limitations under the License.
+   */
+  -->
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>hbase-thirdparty</artifactId>
+        <groupId>org.apache.hbase.thirdparty</groupId>
+        <version>3.2.1-SNAPSHOT</version>
+        <relativePath>..</relativePath>
+    </parent>
+    <artifactId>hbase-shaded-jaeger</artifactId>
+    <name>Apache HBase Relocated (Shaded) JaegerTracing Libs</name>
+    <description>The shaded uber jar of JaegerTracing library used by HBase.</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.jaegertracing</groupId>
+            <artifactId>jaeger-client</artifactId>
+            <version>${jaegertracing.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <!--Make it so assembly:single does nothing in here-->
+                    <artifactId>maven-assembly-plugin</artifactId>
+                    <configuration>
+                        <skipAssembly>true</skipAssembly>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-shade-plugin</artifactId>
+                    <executions>
+                        <execution>
+                            <id>aggregate-into-a-jar-with-relocated-third-parties</id>
+                            <phase>package</phase>
+                            <goals>
+                                <goal>shade</goal>
+                            </goals>
+                            <configuration>
+                                <createSourcesJar>false</createSourcesJar>
+                                <shadedArtifactAttached>false</shadedArtifactAttached>
+                                <shadeTestJar>false</shadeTestJar>
+
+                                <artifactSet>
+                                    <excludes>
+                                        <exclude>org.apache.httpcomponents:httpclient</exclude>
+                                        <exclude>commons-logging:commons-logging</exclude>
+                                        <exclude>commons-codec:commons-codec</exclude>
+                                        <exclude>org.apache.httpcomponents:httpcore</exclude>
+                                        <exclude>javax.annotation:javax.annotation-api</exclude>
+                                        <exclude>org.slf4j:slf4j-api</exclude>
+                                        <exclude>io.opentracing:*</exclude>
+                                    </excludes>
+                                </artifactSet>
+
+                                <relocations>
+                                    <!-- shade gson, which is transitively included via jaeger-core -->
+                                    <relocation>
+                                        <pattern>com.google.gson</pattern>
+                                        <shadedPattern>${rename.offset}.io.jaegertracing.com.google.gson</shadedPattern>
+                                    </relocation>
+
+                                    <!-- shade jaeger-thrift and its dependencies -->
+                                    <relocation>
+                                        <pattern>io.jaegertracing.thriftjava</pattern>
+                                        <shadedPattern>${rename.offset}.io.jaegertracing.thriftjava</shadedPattern>
+                                    </relocation>
+                                    <relocation>
+                                        <pattern>io.jaegertracing.crossdock</pattern>
+                                        <shadedPattern>${rename.offset}.io.jaegertracing.crossdock</shadedPattern>
+                                    </relocation>
+                                    <relocation>
+                                        <pattern>io.jaegertracing.thrift</pattern>
+                                        <shadedPattern>${rename.offset}.io.jaegertracing.thrift</shadedPattern>
+                                    </relocation>
+                                    <relocation>
+                                        <pattern>io.jaegertracing.agent</pattern>
+                                        <shadedPattern>${rename.offset}.io.jaegertracing.agent</shadedPattern>
+                                    </relocation>
+
+                                    <relocation>
+                                        <pattern>org.apache.thrift</pattern>
+                                        <shadedPattern>${rename.offset}.io.jaegertracing.apache.thrift</shadedPattern>
+                                    </relocation>
+                                    <relocation>
+                                        <pattern>com.twitter.zipkin</pattern>
+                                        <shadedPattern>${rename.offset}.io.jaegertracing.com.twitter.zipkin</shadedPattern>
+                                    </relocation>
+                                    <relocation>
+                                        <pattern>okhttp3</pattern>
+                                        <shadedPattern>${rename.offset}.io.jaegertracing.okhttp3</shadedPattern>
+                                    </relocation>
+                                    <relocation>
+                                        <pattern>kotlin</pattern>
+                                        <shadedPattern>${rename.offset}.io.jaegertracing.kotlin</shadedPattern>
+                                    </relocation>
+                                    <relocation>
+                                        <pattern>org.intellij</pattern>
+                                        <shadedPattern>${rename.offset}.io.jaegertracing.org.intellij</shadedPattern>
+                                    </relocation>
+                                    <relocation>
+                                        <pattern>org.jetbrains</pattern>
+                                        <shadedPattern>${rename.offset}.io.jaegertracing.org.jetbrains</shadedPattern>
+                                    </relocation>
+                                    <!-- top level okio -->
+                                    <relocation>
+                                        <pattern>okio</pattern>
+                                        <shadedPattern>${rename.offset}.io.jaegertracing.okio</shadedPattern>
+                                    </relocation>
+
+                                </relocations>
+                                <transformers>
+                                    <!-- Need to filter out some extraneous license files.
+                                         Don't use the ApacheLicenseRT because it just removes all
+                                         META-INF/LICENSE(.txt)? files, including ours. -->
+                                    <transformer implementation="org.apache.maven.plugins.shade.resource.DontIncludeResourceTransformer">
+                                        <resources>
+                                            <resource>LICENSE.txt</resource>
+                                            <resource>ASL2.0</resource>
+                                            <!-- also this unneeded doc -->
+                                            <resource>overview.html</resource>
+                                        </resources>
+                                    </transformer>
+                                    <!-- Where notices exist, just concat them -->
+                                    <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer">
+                                        <addHeader>false</addHeader>
+                                        <projectName>${project.name}</projectName>
+                                    </transformer>
+                                    <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer">
+                                    </transformer>
+                                </transformers>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+        <plugins>
+            <plugin>
+                <!--Make it so assembly:single does nothing in here-->
+                <artifactId>maven-assembly-plugin</artifactId>
+                <configuration>
+                    <skipAssembly>true</skipAssembly>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/hbase-shaded-miscellaneous/pom.xml
+++ b/hbase-shaded-miscellaneous/pom.xml
@@ -32,7 +32,7 @@
   <parent>
     <groupId>org.apache.hbase.thirdparty</groupId>
     <artifactId>hbase-thirdparty</artifactId>
-    <version>3.2.1-SNAPSHOT</version>
+    <version>3.3.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>hbase-shaded-miscellaneous</artifactId>

--- a/hbase-shaded-netty/pom.xml
+++ b/hbase-shaded-netty/pom.xml
@@ -32,7 +32,7 @@
   <parent>
     <groupId>org.apache.hbase.thirdparty</groupId>
     <artifactId>hbase-thirdparty</artifactId>
-    <version>3.2.1-SNAPSHOT</version>
+    <version>3.3.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>hbase-shaded-netty</artifactId>

--- a/hbase-shaded-protobuf/pom.xml
+++ b/hbase-shaded-protobuf/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.hbase.thirdparty</groupId>
     <artifactId>hbase-thirdparty</artifactId>
-    <version>3.2.1-SNAPSHOT</version>
+    <version>3.3.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>hbase-shaded-protobuf</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,7 @@
     <commons-cli.version>1.4</commons-cli.version>
     <commons-collections.version>4.4</commons-collections.version>
     <error_prone_annotations.version>2.3.4</error_prone_annotations.version>
-    <jaegertracing.version>0.34.2</jaegertracing.version>
+    <jaegertracing.version>1.2.0</jaegertracing.version>
   </properties>
   <build>
     <pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,7 @@
     <module>hbase-shaded-protobuf</module>
     <module>hbase-shaded-netty</module>
     <module>hbase-shaded-gson</module>
+    <module>hbase-shaded-jaeger</module>
     <module>hbase-shaded-miscellaneous</module>
   </modules>
   <scm>
@@ -133,6 +134,7 @@
     <commons-cli.version>1.4</commons-cli.version>
     <commons-collections.version>4.4</commons-collections.version>
     <error_prone_annotations.version>2.3.4</error_prone_annotations.version>
+    <jaegertracing.version>0.34.2</jaegertracing.version>
   </properties>
   <build>
     <pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
   </parent>
   <groupId>org.apache.hbase.thirdparty</groupId>
   <artifactId>hbase-thirdparty</artifactId>
-  <version>3.2.1-SNAPSHOT</version>
+  <version>3.3.0-SNAPSHOT</version>
   <name>Apache HBase Third-Party Libs</name>
   <packaging>pom</packaging>
   <description>


### PR DESCRIPTION
This commit adds a new artifact org.hbase.thirdparty:hbase-shaded-jaeger.
It shades io.jagertracing:jaeger-client and its dependencies, relocating
the classpath. In particular, it requires libthrift 0.13.0 which is
incompatible with libthrift 0.12.0 shipped by the current HBase.

Dependencies that are already included by hbase-common are excluded from
the uber jar. The resulting jar is about 3.9 MB in size.