### PR TITLE
HBASE-19146 Update Protobuf to 3.11.4

### DIFF
--- a/hbase-shaded-protobuf/pom.xml
+++ b/hbase-shaded-protobuf/pom.xml
@@ -34,10 +34,6 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-source-plugin</artifactId>
-      </plugin>
-      <plugin>
         <!--Clean needs to purge src/main/java since this is where
              the unpack of protobuf is overlaid. Do it for usual
              clean goal but also before we unpack in case patches

--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
     <java.min.version>${compileSource}</java.min.version>
     <maven.min.version>3.3.3</maven.min.version>
     <rename.offset>org.apache.hbase.thirdparty</rename.offset>
-    <protobuf.version>3.11.1</protobuf.version>
+    <protobuf.version>3.11.4</protobuf.version>
     <netty.version>4.1.45.Final</netty.version>
     <guava.version>28.2-jre</guava.version>
     <commons-cli.version>1.4</commons-cli.version>


### PR DESCRIPTION
Remove duplicate entry of maven-source-plugin. It was causing a warning in Maven builds.