### PR TITLE
HBASE-24858 Exclude the current modules jar from the shading step

### DIFF
--- a/hbase-shaded-jersey/pom.xml
+++ b/hbase-shaded-jersey/pom.xml
@@ -101,6 +101,11 @@
                   <exclude>jakarta.validation:jakarta.validation-api</exclude>
                   <exclude>org.glassfish.hk2.external:jakarta.inject</exclude>
                   <exclude>org.javassist:javassist</exclude>
+                  <!-- On the "next" build, exclude a lingering shaded jar if it exists (user did not `clean`).
+                    Maven will happily pick up the previous shaded jar and try to include that in the N+1th build
+                    if we don't exclude it. This will result in a failure in the ServicesResourceTransformer claiming
+                    that we've already packaged a services file once. -->
+                  <exclude>org.apache.hbase.thirdparty:hbase-shaded-jersey</exclude>
                 </excludes>
               </artifactSet>
               <transformers>

--- a/hbase-shaded-jetty/pom.xml
+++ b/hbase-shaded-jetty/pom.xml
@@ -90,6 +90,11 @@
                       produce. See below for how to exclusion of transitive dependencies.
                     -->
                   <exclude>javax.servlet:javax.servlet-api</exclude>
+                  <!-- On the "next" build, exclude a lingering shaded jar if it exists (user did not `clean`).
+                    Maven will happily pick up the previous shaded jar and try to include that in the N+1th build
+                    if we don't exclude it. This will result in a failure in the ServicesResourceTransformer claiming
+                    that we've already packaged a services file once. -->
+                  <exclude>org.apache.hbase.thirdparty:hbase-shaded-jetty</exclude>
                 </excludes>
               </artifactSet>
               <transformers>


### PR DESCRIPTION
When a module's jar from the previous build of that module is left in
place, replacing the main artifact for that module, the next build of
that module will happen to pick up the shaded jar and try to re-shaded
that jar.

This is unexpected, as we're reading through all of the module's
dependencies and unpackaging/relocating each of them. We do not expect
to be getting them from the modules main artifact.

The easy solution is that we just always exclude this modules jar. Given
that these modules have no source (just a repacking of thirdparty
projects), this is safe for us to do. Best as I can tell, the resulting
jars are equivalently built.

Also tagging Busbey as a resident-Maven-expert