### PR TITLE
HBASE-25728 [hbase-thirdparty] Upgrade Netty library to >= 4.1.60 due to security vulnerability CVE-2021-21295

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,7 +130,7 @@
     <maven.min.version>3.3.3</maven.min.version>
     <rename.offset>org.apache.hbase.thirdparty</rename.offset>
     <protobuf.version>3.13.0</protobuf.version>
-    <netty.version>4.1.53.Final</netty.version>
+    <netty.version>4.1.63.Final</netty.version>
     <guava.version>30.0-jre</guava.version>
     <commons-cli.version>1.4</commons-cli.version>
     <commons-collections.version>4.4</commons-collections.version>


### PR DESCRIPTION
We don't have a direct exposure to this vulnerability but vulnerability scanners aware of the CVE database may flag it. 