### PR TITLE
HBASE-25855 Fix typo in jersey relocation path

### DIFF
--- a/hbase-shaded-jersey/pom.xml
+++ b/hbase-shaded-jersey/pom.xml
@@ -74,7 +74,7 @@
                 </relocation>
                 <relocation>
                   <pattern>jersey</pattern>
-                  <shadedPattern>${rename.offset}.jersery</shadedPattern>
+                  <shadedPattern>${rename.offset}.jersey</shadedPattern>
                 </relocation>
                 <relocation>
                   <pattern>com.sun.research</pattern>


### PR DESCRIPTION
We shade to "jersery" instead of "jersey".