### PR TITLE
HBASE-25863 Shade javax.ws.rs package for use with shaded Jersey

### DIFF
--- a/hbase-shaded-jackson-jaxrs-json-provider/pom.xml
+++ b/hbase-shaded-jackson-jaxrs-json-provider/pom.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <!--
+  /**
+   * Licensed to the Apache Software Foundation (ASF) under one
+   * or more contributor license agreements.  See the NOTICE file
+   * distributed with this work for additional information
+   * regarding copyright ownership.  The ASF licenses this file
+   * to you under the Apache License, Version 2.0 (the
+   * "License"); you may not use this file except in compliance
+   * with the License.  You may obtain a copy of the License at
+   *
+   *     http://www.apache.org/licenses/LICENSE-2.0
+   *
+   * Unless required by applicable law or agreed to in writing, software
+   * distributed under the License is distributed on an "AS IS" BASIS,
+   * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   * See the License for the specific language governing permissions and
+   * limitations under the License.
+   */
+
+
+    ON MVN COMPILE NOT WORKING
+
+    If you wondering why 'mvn compile' does not work building HBase
+    (in particular, if you are doing it for the first time), instead do
+    'mvn package'.  If you are interested in the full story, see
+    https://issues.apache.org/jira/browse/HBASE-6795.
+
+  -->
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.hbase.thirdparty</groupId>
+        <artifactId>hbase-thirdparty</artifactId>
+        <version>4.0.0-SNAPSHOT</version>
+        <relativePath>..</relativePath>
+    </parent>
+    <artifactId>hbase-shaded-jackson-jaxrs-json-provider</artifactId>
+    <name>Apache HBase Relocated (Shaded) jackson-jaxrs-json-provider</name>
+    <description>
+        Pulls down jackson-jaxrs-json-provider, relocates it, and rewrites its usage of javax.ws.rs
+        classes to make the relocated versions provided by hbase-shaded-jersey. Does NOT
+        include/relocate its entire dependency graph, just performs this isolated transform.
+
+        This is a separate module because jackson-jaxrs-json-provider is not used universally. At
+        this time, the dependency is required only by hbase-rest.
+    </description>
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-clean-plugin</artifactId>
+                <configuration>
+                    <filesets>
+                        <fileset>
+                            <directory>${basedir}</directory>
+                            <includes>
+                                <include>dependency-reduced-pom.xml</include>
+                            </includes>
+                        </fileset>
+                    </filesets>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <shadeSourcesContent>true</shadeSourcesContent>
+                            <createSourcesJar>true</createSourcesJar>
+                            <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
+                            <relocations>
+                                <relocation>
+                                    <pattern>javax.ws.rs</pattern>
+                                    <shadedPattern>${rename.offset}.javax.ws.rs</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.fasterxml.jackson.jaxrs</pattern>
+                                    <shadedPattern>${rename.offset}.com.fasterxml.jackson.jaxrs</shadedPattern>
+                                </relocation>
+                            </relocations>
+                            <artifactSet>
+                                <includes>
+                                    <include>com.fasterxml.jackson.jaxrs:jackson-jaxrs-base</include>
+                                    <include>com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider</include>
+                                </includes>
+                            </artifactSet>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer">
+                                </transformer>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer">
+                                    <addHeader>false</addHeader>
+                                </transformer>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                            </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+    <dependencies>
+        <dependency>
+            <groupId>com.fasterxml.jackson.jaxrs</groupId>
+            <artifactId>jackson-jaxrs-json-provider</artifactId>
+            <version>${jackson-jaxrs-json-provider.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/hbase-shaded-jersey/pom.xml
+++ b/hbase-shaded-jersey/pom.xml
@@ -69,6 +69,10 @@
               <createSourcesJar>true</createSourcesJar>
               <relocations>
                 <relocation>
+                  <pattern>javax.ws.rs</pattern>
+                  <shadedPattern>${rename.offset}.javax.ws.rs</shadedPattern>
+                </relocation>
+                <relocation>
                   <pattern>org.glassfish</pattern>
                   <shadedPattern>${rename.offset}.org.glassfish</shadedPattern>
                 </relocation>
@@ -96,7 +100,6 @@
                       also else we give an odd signal in the META-INF/DEPENDENCIES that we
                       produce. See below for how to exclusion of transitive dependencies.
                     -->
-                  <exclude>jakarta.ws.rs:jakarta.ws.rs-api</exclude>
                   <exclude>jakarta.annotation:jakarta.annotation-api</exclude>
                   <exclude>jakarta.validation:jakarta.validation-api</exclude>
                   <exclude>org.glassfish.hk2.external:jakarta.inject</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,7 @@
     <module>hbase-shaded-miscellaneous</module>
     <module>hbase-shaded-jetty</module>
     <module>hbase-shaded-jersey</module>
+    <module>hbase-shaded-jackson-jaxrs-json-provider</module>
     <module>hbase-noop-htrace</module>
   </modules>
   <scm>
@@ -144,6 +145,7 @@
     <jakarta.annotation-api.version>1.3.5</jakarta.annotation-api.version>
     <jakarta.validation-api.version>2.0.2</jakarta.validation-api.version>
     <javassist.version>3.25.0-GA</javassist.version>
+    <jackson-jaxrs-json-provider.version>2.10.1</jackson-jaxrs-json-provider.version>
   </properties>
   <build>
     <pluginManagement>


### PR DESCRIPTION
From the [About](https://eclipse-ee4j.github.io/jersey/) text,

> Jersey RESTful Web Services 2.x framework is open source, production quality, framework for
> developing RESTful Web Services in Java that provides support for JAX-RS APIs and serves as a
> JAX-RS (JSR 311 & JSR 339 & JSR 370) Reference Implementation.

`javax.ws.rs` is defined by the JSRs, so it doesn't make sense that we could have multiple
implementations of that JSR on the classpath simultaniously (via jersey-server-1.x and
jersey-server-2.x jars) without them colliding. By shading over the JSR package space in the
jersey-server-2.x implementation jars, we achieve a completely isolated JSR runtime.