### PR TITLE
HBASE-26732 [hbase-thirdparty] Update jackson (databind) to 2.13.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -145,7 +145,7 @@
     <jakarta.annotation-api.version>1.3.5</jakarta.annotation-api.version>
     <jakarta.validation-api.version>2.0.2</jakarta.validation-api.version>
     <javassist.version>3.25.0-GA</javassist.version>
-    <jackson-jaxrs-json-provider.version>2.10.1</jackson-jaxrs-json-provider.version>
+    <jackson-jaxrs-json-provider.version>2.13.1</jackson-jaxrs-json-provider.version>
   </properties>
   <build>
     <pluginManagement>


### PR DESCRIPTION
Update jackson-databind to 2.13.1 to address a raised vulnerability that could possible DoS attack certain versions of Jackson. Please refer to https://github.com/FasterXML/jackson-databind/issues/3328 for further info.