### PR TITLE
HBASE-26733 [hbase-thirdparty] Upgrade Netty to 4.1.73.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,7 @@
     <maven.min.version>3.3.3</maven.min.version>
     <rename.offset>org.apache.hbase.thirdparty</rename.offset>
     <protobuf.version>3.19.1</protobuf.version>
-    <netty.version>4.1.70.Final</netty.version>
+    <netty.version>4.1.73.Final</netty.version>
     <guava.version>31.0.1-jre</guava.version>
     <commons-cli.version>1.5.0</commons-cli.version>
     <commons-collections.version>4.4</commons-collections.version>


### PR DESCRIPTION
Netty 4.1.71.Final included a fix for [HTTP-request-smuggling](https://github.com/netty/netty/security/advisories/GHSA-wx5j-54mm-rqqq). We are still on 4.1.70.Final.

Latest is 4.1.73.Final, use that.