### PR TITLE
HBASE-28075 [hbase-thirdparty] Add shaded netty tcnative module

### DIFF
--- a/hbase-shaded-netty-tcnative/pom.xml
+++ b/hbase-shaded-netty-tcnative/pom.xml
@@ -42,13 +42,6 @@
       <groupId>io.netty</groupId>
       <artifactId>netty-tcnative-boringssl-static</artifactId>
       <version>${netty.tcnative.version}</version>
-      <classifier>linux-x86_64</classifier>
-    </dependency>
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-tcnative-boringssl-static</artifactId>
-      <version>${netty.tcnative.version}</version>
-      <classifier>linux-aarch_64</classifier>
     </dependency>
   </dependencies>
   <build>
@@ -121,7 +114,9 @@
             <configuration>
               <target>
                 <echo message="unjar" />
-                <unzip src="${project.build.directory}/${project.artifactId}-${project.version}.jar" dest="${project.build.directory}/unpacked/" />
+                <unzip src="${project.build.directory}/${project.artifactId}-${project.version}.jar" dest="${project.build.directory}/unpacked/">
+                  <mapper type="regexp" from="META-INF/license/(LICENSE.*.txt)$$" to="META-INF/\1"/>
+                </unzip>
                 <echo message="Rename netty .so in META-INF"/>
                 <move file="${project.build.directory}/unpacked/META-INF/native/libnetty_tcnative_linux_x86_64.so" tofile="${project.build.directory}/unpacked/META-INF/native/liborg_apache_hbase_thirdparty_netty_tcnative_linux_x86_64.so"/>
                 <move file="${project.build.directory}/unpacked/META-INF/native/libnetty_tcnative_linux_aarch_64.so" tofile="${project.build.directory}/unpacked/META-INF/native/liborg_apache_hbase_thirdparty_netty_tcnative_linux_aarch_64.so"/>

--- a/hbase-shaded-netty-tcnative/pom.xml
+++ b/hbase-shaded-netty-tcnative/pom.xml
@@ -101,11 +101,11 @@
             property so netty finds the renamed .so and associates it w/ the relocated netty files.
 
             Add this define when running unit tests:
-            
+
                mvn test -Dorg.apache.hbase.thirdparty.io.netty.packagePrefix=org.apache.hbase.thirdparty. -Dtest=TestNettyIPC
 
             See toward the end of this issue for how to pass config:
-            
+
               https://github.com/netty/netty/issues/6665
 
             TODO: Ensure native works.

--- a/hbase-shaded-netty-tcnative/pom.xml
+++ b/hbase-shaded-netty-tcnative/pom.xml
@@ -82,6 +82,11 @@
                   <include>io.netty:*</include>
                 </includes>
               </artifactSet>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer">
+                  <addHeader>false</addHeader>
+                </transformer>
+              </transformers>
             </configuration>
           </execution>
         </executions>
@@ -115,6 +120,9 @@
               <target>
                 <echo message="unjar" />
                 <unzip src="${project.build.directory}/${project.artifactId}-${project.version}.jar" dest="${project.build.directory}/unpacked/">
+                  <patternset>
+                    <exclude name="META-INF/LICENSE.txt"/>
+                  </patternset>
                   <mapper type="regexp" from="META-INF/license/(LICENSE.*.txt)$$" to="META-INF/\1"/>
                 </unzip>
                 <echo message="Rename netty .so in META-INF"/>

--- a/hbase-shaded-netty-tcnative/pom.xml
+++ b/hbase-shaded-netty-tcnative/pom.xml
@@ -131,8 +131,6 @@
                 <echo message="Rename netty .jnilib in META-INF" />
                 <move file="${project.build.directory}/unpacked/META-INF/native/libnetty_tcnative_osx_x86_64.jnilib" tofile="${project.build.directory}/unpacked/META-INF/native/liborg_apache_hbase_thirdparty_netty_tcnative_osx_x86_64.jnilib" />
                 <move file="${project.build.directory}/unpacked/META-INF/native/libnetty_tcnative_osx_aarch_64.jnilib" tofile="${project.build.directory}/unpacked/META-INF/native/liborg_apache_hbase_thirdparty_netty_tcnative_osx_aarch_64.jnilib" />
-                <echo message="Remove netty .dll file in META-INF" />
-                <delete file="${project.build.directory}/unpacked/META-INF/native/netty_tcnative_windows_x86_64.dll" />
                 <echo message="Redo jar" />
                 <jar basedir="${project.build.directory}/unpacked" destfile="${project.build.directory}/${project.artifactId}-${project.version}.jar"/>
               </target>

--- a/hbase-shaded-netty-tcnative/pom.xml
+++ b/hbase-shaded-netty-tcnative/pom.xml
@@ -1,0 +1,145 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <!--
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+  ON MVN COMPILE NOT WORKING
+
+  If you wondering why 'mvn compile' does not work building HBase
+  (in particular, if you are doing it for the first time), instead do
+  'mvn package'.  If you are interested in the full story, see
+  https://issues.apache.org/jira/browse/HBASE-6795.
+
+-->
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.hbase.thirdparty</groupId>
+    <artifactId>hbase-thirdparty</artifactId>
+    <version>${revision}</version>
+    <relativePath>..</relativePath>
+  </parent>
+  <artifactId>hbase-shaded-netty-tcnative</artifactId>
+  <name>Apache HBase Relocated (Shaded) netty-tcnative Libs</name>
+  <dependencies>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-tcnative-boringssl-static</artifactId>
+      <version>${netty.tcnative.version}</version>
+      <classifier>linux-x86_64</classifier>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-tcnative-boringssl-static</artifactId>
+      <version>${netty.tcnative.version}</version>
+      <classifier>linux-aarch_64</classifier>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-clean-plugin</artifactId>
+        <configuration>
+          <filesets>
+            <fileset>
+              <directory>${basedir}</directory>
+              <includes>
+                <include>dependency-reduced-pom.xml</include>
+              </includes>
+            </fileset>
+          </filesets>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <shadeSourcesContent>true</shadeSourcesContent>
+              <createSourcesJar>true</createSourcesJar>
+              <relocations>
+                <relocation>
+                  <pattern>io.netty</pattern>
+                  <shadedPattern>${rename.offset}.io.netty</shadedPattern>
+                </relocation>
+              </relocations>
+              <artifactSet>
+                <includes>
+                  <include>io.netty:*</include>
+                </includes>
+              </artifactSet>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <!--This trick from
+             https://stackoverflow.com/questions/33825743/rename-files-inside-a-jar-using-some-maven-plugin
+
+            The netty jar has a .so in it. Shading requires rename of the .so and then passing a system
+            property so netty finds the renamed .so and associates it w/ the relocated netty files.
+
+            Add this define when running unit tests:
+            
+               mvn test -Dorg.apache.hbase.thirdparty.io.netty.packagePrefix=org.apache.hbase.thirdparty. -Dtest=TestNettyIPC
+
+            See toward the end of this issue for how to pass config:
+            
+              https://github.com/netty/netty/issues/6665
+
+            TODO: Ensure native works.
+            NOTE: The 'tofile' in the move command below has the relocation hard-coded
+            with '-' instead of '.' separators. If change the relocation, need to change here too.
+          -->
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>unpack</id>
+            <phase>package</phase>
+            <configuration>
+              <target>
+                <echo message="unjar" />
+                <unzip src="${project.build.directory}/${project.artifactId}-${project.version}.jar" dest="${project.build.directory}/unpacked/" />
+                <echo message="Rename netty .so in META-INF"/>
+                <move file="${project.build.directory}/unpacked/META-INF/native/libnetty_tcnative_linux_x86_64.so" tofile="${project.build.directory}/unpacked/META-INF/native/liborg_apache_hbase_thirdparty_netty_tcnative_linux_x86_64.so"/>
+                <move file="${project.build.directory}/unpacked/META-INF/native/libnetty_tcnative_linux_aarch_64.so" tofile="${project.build.directory}/unpacked/META-INF/native/liborg_apache_hbase_thirdparty_netty_tcnative_linux_aarch_64.so"/>
+                <echo message="Rename netty .jnilib in META-INF" />
+                <move file="${project.build.directory}/unpacked/META-INF/native/libnetty_tcnative_osx_x86_64.jnilib" tofile="${project.build.directory}/unpacked/META-INF/native/liborg_apache_hbase_thirdparty_netty_tcnative_osx_x86_64.jnilib" />
+                <move file="${project.build.directory}/unpacked/META-INF/native/libnetty_tcnative_osx_aarch_64.jnilib" tofile="${project.build.directory}/unpacked/META-INF/native/liborg_apache_hbase_thirdparty_netty_tcnative_osx_aarch_64.jnilib" />
+                <echo message="Remove netty .dll file in META-INF" />
+                <delete file="${project.build.directory}/unpacked/META-INF/native/netty_tcnative_windows_x86_64.dll" />
+                <echo message="Redo jar" />
+                <jar basedir="${project.build.directory}/unpacked" destfile="${project.build.directory}/${project.artifactId}-${project.version}.jar"/>
+              </target>
+            </configuration>
+            <goals>
+              <goal>run</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,7 @@
   <modules>
     <module>hbase-shaded-protobuf</module>
     <module>hbase-shaded-netty</module>
+    <module>hbase-shaded-netty-tcnative</module>
     <module>hbase-shaded-gson</module>
     <module>hbase-shaded-miscellaneous</module>
     <module>hbase-shaded-jetty</module>
@@ -134,6 +135,7 @@
     <rename.offset>org.apache.hbase.thirdparty</rename.offset>
     <protobuf.version>3.24.3</protobuf.version>
     <netty.version>4.1.97.Final</netty.version>
+    <netty.tcnative.version>2.0.61.Final</netty.tcnative.version>
     <guava.version>32.1.2-jre</guava.version>
     <commons-cli.version>1.5.0</commons-cli.version>
     <commons-collections.version>4.4</commons-collections.version>


### PR DESCRIPTION
Note: This fails to build on Mac OS, because of the case-insensitive file-system. The jar contains a META-INF/LICENSE file and META-INF/license directory, which causes unzip to fail. With antrun version 1.8 (as we use in hbase), the error is printed as a warn. With antrun version 3.1.0 (which we use here), it fails the build.

I'm not quite sure of the best way to work around that. I could try excluding either LICENSE or license or both? Not sure if we need to retain them?

Anyway, with antrun 1.8, this provides the following jar contents:

```
META-INF/
META-INF/MANIFEST.MF
META-INF/maven/
META-INF/maven/io.netty/
META-INF/maven/io.netty/netty-tcnative-boringssl-static/
META-INF/maven/io.netty/netty-tcnative-classes/
META-INF/maven/org.apache.hbase.thirdparty/
META-INF/maven/org.apache.hbase.thirdparty/hbase-shaded-netty-tcnative/
META-INF/native/
org/
org/apache/
org/apache/hbase/
org/apache/hbase/thirdparty/
org/apache/hbase/thirdparty/io/
org/apache/hbase/thirdparty/io/netty/
org/apache/hbase/thirdparty/io/netty/internal/
org/apache/hbase/thirdparty/io/netty/internal/tcnative/
META-INF/DEPENDENCIES
META-INF/LICENSE
META-INF/LICENSE.aix-netbsd.txt
META-INF/LICENSE.boringssl.txt
META-INF/LICENSE.mvn-wrapper.txt
META-INF/LICENSE.tomcat-native.txt
META-INF/LICENSE.txt
META-INF/NOTICE
META-INF/NOTICE.txt
META-INF/maven/io.netty/netty-tcnative-boringssl-static/pom.properties
META-INF/maven/io.netty/netty-tcnative-boringssl-static/pom.xml
META-INF/maven/io.netty/netty-tcnative-classes/pom.properties
META-INF/maven/io.netty/netty-tcnative-classes/pom.xml
META-INF/maven/org.apache.hbase.thirdparty/hbase-shaded-netty-tcnative/pom.properties
META-INF/maven/org.apache.hbase.thirdparty/hbase-shaded-netty-tcnative/pom.xml
META-INF/native/liborg_apache_hbase_thirdparty_netty_tcnative_linux_aarch_64.so
META-INF/native/liborg_apache_hbase_thirdparty_netty_tcnative_linux_x86_64.so
META-INF/native/liborg_apache_hbase_thirdparty_netty_tcnative_osx_aarch_64.jnilib
META-INF/native/liborg_apache_hbase_thirdparty_netty_tcnative_osx_x86_64.jnilib
org/apache/hbase/thirdparty/io/netty/internal/tcnative/AsyncSSLPrivateKeyMethod.class
org/apache/hbase/thirdparty/io/netty/internal/tcnative/AsyncSSLPrivateKeyMethodAdapter.class
org/apache/hbase/thirdparty/io/netty/internal/tcnative/AsyncTask.class
org/apache/hbase/thirdparty/io/netty/internal/tcnative/Buffer.class
org/apache/hbase/thirdparty/io/netty/internal/tcnative/CertificateCallback.class
org/apache/hbase/thirdparty/io/netty/internal/tcnative/CertificateCallbackTask.class
org/apache/hbase/thirdparty/io/netty/internal/tcnative/CertificateCompressionAlgo.class
org/apache/hbase/thirdparty/io/netty/internal/tcnative/CertificateRequestedCallback.class
org/apache/hbase/thirdparty/io/netty/internal/tcnative/CertificateVerifier.class
org/apache/hbase/thirdparty/io/netty/internal/tcnative/CertificateVerifierTask.class
org/apache/hbase/thirdparty/io/netty/internal/tcnative/Library.class
org/apache/hbase/thirdparty/io/netty/internal/tcnative/NativeStaticallyReferencedJniMethods.class
org/apache/hbase/thirdparty/io/netty/internal/tcnative/ResultCallback.class
org/apache/hbase/thirdparty/io/netty/internal/tcnative/SSL.class
org/apache/hbase/thirdparty/io/netty/internal/tcnative/SSLContext.class
org/apache/hbase/thirdparty/io/netty/internal/tcnative/SSLPrivateKeyMethod.class
org/apache/hbase/thirdparty/io/netty/internal/tcnative/SSLPrivateKeyMethodDecryptTask.class
org/apache/hbase/thirdparty/io/netty/internal/tcnative/SSLPrivateKeyMethodSignTask.class
org/apache/hbase/thirdparty/io/netty/internal/tcnative/SSLPrivateKeyMethodTask$1.class
org/apache/hbase/thirdparty/io/netty/internal/tcnative/SSLPrivateKeyMethodTask.class
org/apache/hbase/thirdparty/io/netty/internal/tcnative/SSLSession.class
org/apache/hbase/thirdparty/io/netty/internal/tcnative/SSLSessionCache.class
org/apache/hbase/thirdparty/io/netty/internal/tcnative/SSLTask$1.class
org/apache/hbase/thirdparty/io/netty/internal/tcnative/SSLTask$2.class
org/apache/hbase/thirdparty/io/netty/internal/tcnative/SSLTask$TaskCallback.class
org/apache/hbase/thirdparty/io/netty/internal/tcnative/SSLTask.class
org/apache/hbase/thirdparty/io/netty/internal/tcnative/SessionTicketKey.class
org/apache/hbase/thirdparty/io/netty/internal/tcnative/SniHostNameMatcher.class
```