### PR TITLE
HBASE-28374 [hbase-thirdparty] bump remaining deps for 4.1.6 release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,23 +134,23 @@
     <maven.min.version>3.3.3</maven.min.version>
     <os.maven.version>1.7.1</os.maven.version>
     <rename.offset>org.apache.hbase.thirdparty</rename.offset>
-    <protobuf.version>3.24.3</protobuf.version>
+    <protobuf.version>3.25.2</protobuf.version>
     <netty.version>4.1.107.Final</netty.version>
     <netty.tcnative.version>2.0.61.Final</netty.tcnative.version>
-    <guava.version>32.1.2-jre</guava.version>
-    <commons-cli.version>1.5.0</commons-cli.version>
+    <guava.version>33.0.0-jre</guava.version>
+    <commons-cli.version>1.6.0</commons-cli.version>
     <commons-collections.version>4.4</commons-collections.version>
     <error_prone_annotations.version>2.21.1</error_prone_annotations.version>
     <gson.version>2.10.1</gson.version>
-    <jetty.version>9.4.53.v20231009</jetty.version>
+    <jetty.version>9.4.54.v20240208</jetty.version>
     <servlet-api.version>3.1.0</servlet-api.version>
-    <jersey.version>2.40</jersey.version>
+    <jersey.version>2.41</jersey.version>
     <jakarta.inject.version>2.6.1</jakarta.inject.version>
     <jakarta.ws.rs-api.version>2.1.6</jakarta.ws.rs-api.version>
     <jakarta.annotation-api.version>1.3.5</jakarta.annotation-api.version>
     <jakarta.validation-api.version>2.0.2</jakarta.validation-api.version>
-    <javassist.version>3.29.2-GA</javassist.version>
-    <jackson-jaxrs-json-provider.version>2.15.2</jackson-jaxrs-json-provider.version>
+    <javassist.version>3.30.2-GA</javassist.version>
+    <jackson-jaxrs-json-provider.version>2.16.1</jackson-jaxrs-json-provider.version>
   </properties>
   <build>
     <pluginManagement>


### PR DESCRIPTION
* protobuf 3.25.2
* guava 33.0.0-jre
* commons-cli 1.6.0
* jetty 9.4.54.v20240208
* jersey 2.41
* javassist 3.30.2-GA
* jackson-jaxrs-json-provider 2.16.1