### PR TITLE
HBASE-28764 [hbase-thirdparty] Bump protobuf version from 4.26.1 to 4.27.3

### DIFF
--- a/hbase-shaded-protobuf/src/main/patches/HBASE-15789_V3.patch
+++ b/hbase-shaded-protobuf/src/main/patches/HBASE-15789_V3.patch
@@ -359,11 +359,11 @@ index 000000000..320977290
 +  }
 +}
 diff --git a/src/main/java/com/google/protobuf/ByteString.java b/src/main/java/com/google/protobuf/ByteString.java
-index 8ba729c8e..62aae86ee 100644
+index 7b2455f12..f906a4774 100644
 --- a/src/main/java/com/google/protobuf/ByteString.java
 +++ b/src/main/java/com/google/protobuf/ByteString.java
-@@ -422,6 +422,13 @@ public abstract class ByteString implements Iterable<Byte>, Serializable {
-     }
+@@ -430,6 +430,13 @@ public abstract class ByteString implements Iterable<Byte>, Serializable {
+     return new NioByteString(buffer);
    }
 
 +  /**
@@ -376,8 +376,17 @@ index 8ba729c8e..62aae86ee 100644
    /**
     * Wraps the given bytes into a {@code ByteString}. Intended for internal usage within the library
     * to force a classload of ByteString before LiteralByteString.
+@@ -961,8 +968,6 @@ public abstract class ByteString implements Iterable<Byte>, Serializable {
+      * @return true for equality of substrings, else false.
+      */
+     abstract boolean equalsRange(ByteString other, int offset, int length);
+-
+-    private LeafByteString() {}
+   }
+ 
+   /**
 diff --git a/src/main/java/com/google/protobuf/CodedInputStream.java b/src/main/java/com/google/protobuf/CodedInputStream.java
-index 224ced529..64c3efa37 100644
+index 81da41778..80fd9153c 100644
 --- a/src/main/java/com/google/protobuf/CodedInputStream.java
 +++ b/src/main/java/com/google/protobuf/CodedInputStream.java
 @@ -178,6 +178,15 @@ public abstract class CodedInputStream {
@@ -396,7 +405,7 @@ index 224ced529..64c3efa37 100644
    /** Disable construction/inheritance outside of this class. */
    private CodedInputStream() {}
  
-@@ -3957,4 +3966,652 @@ public abstract class CodedInputStream {
+@@ -3970,4 +3979,652 @@ public abstract class CodedInputStream {
        }
      }
    }
@@ -1265,3 +1274,4 @@ index d52006754..92ed1f1f7 100644
      /**
       * Encodes an input character sequence ({@code in}) to UTF-8 in the target array ({@code out}).
       * For a string, this method is similar to
+

--- a/hbase-shaded-protobuf/src/main/patches/HBASE-17239.patch
+++ b/hbase-shaded-protobuf/src/main/patches/HBASE-17239.patch
@@ -1,5 +1,5 @@
 diff --git a/src/main/java/com/google/protobuf/CodedInputStream.java b/src/main/java/com/google/protobuf/CodedInputStream.java
-index 64c3efa37..a5455e7f5 100644
+index 80fd9153c..11de874dd 100644
 --- a/src/main/java/com/google/protobuf/CodedInputStream.java
 +++ b/src/main/java/com/google/protobuf/CodedInputStream.java
 @@ -179,11 +179,7 @@ public abstract class CodedInputStream {
@@ -16,10 +16,10 @@ index 64c3efa37..a5455e7f5 100644
    }
  
 diff --git a/src/main/java/com/google/protobuf/UnsafeByteOperations.java b/src/main/java/com/google/protobuf/UnsafeByteOperations.java
-index 06121780f..3afb65965 100644
+index 15c1da969..54d2f975a 100644
 --- a/src/main/java/com/google/protobuf/UnsafeByteOperations.java
 +++ b/src/main/java/com/google/protobuf/UnsafeByteOperations.java
-@@ -75,6 +75,17 @@ public final class UnsafeByteOperations {
+@@ -74,6 +74,17 @@ public final class UnsafeByteOperations {
      return ByteString.wrap(buffer);
    }
  
@@ -37,3 +37,4 @@ index 06121780f..3afb65965 100644
    /**
     * Writes the given {@link ByteString} to the provided {@link ByteOutput}. Calling this method may
     * result in multiple operations on the target {@link ByteOutput} (i.e. for roped {@link
+

--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,7 @@
     <maven.min.version>3.3.3</maven.min.version>
     <os.maven.version>1.7.1</os.maven.version>
     <rename.offset>org.apache.hbase.thirdparty</rename.offset>
-    <protobuf.version>4.26.1</protobuf.version>
+    <protobuf.version>4.27.3</protobuf.version>
     <netty.version>4.1.112.Final</netty.version>
     <netty.tcnative.version>2.0.61.Final</netty.tcnative.version>
     <guava.version>33.2.1-jre</guava.version>


### PR DESCRIPTION
This PR contains following changes,

Bump protobuf version from 4.26.1 to 4.27.3
Recreate the patch HBASE-15789_V2.patch with private constructor of ByteString.LeafByteString
Recreate the patch HBASE-17087.patch & HBASE-17239.patch