### PR TITLE
HBASE-28967 [hbase-thirdparty] add jersey-media-json-jackson in  hbas…

### DIFF
--- a/hbase-shaded-jersey/pom.xml
+++ b/hbase-shaded-jersey/pom.xml
@@ -177,6 +177,11 @@
       <version>${jersey.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.glassfish.jersey.media</groupId>
+      <artifactId>jersey-media-json-jackson</artifactId>
+      <version>${jersey.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.glassfish.jersey.inject</groupId>
       <artifactId>jersey-hk2</artifactId>
       <version>${jersey.version}</version>


### PR DESCRIPTION
In a REST service built using hbase-shaded-jersey.jar, I'm unable to convert a Response object into a JSON string.
The reason I cannot convert a Response object to a JSON string in my REST service built with hbase-shaded-jersey.jar is because it lacks the necessary dependencies from jersey-media-json-jackson.