### PR TITLE
HBASE-29059 [hbase-thirdparty] Bump dependencies for hbase-thirdparty…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,22 +135,22 @@
     <os.maven.version>1.7.1</os.maven.version>
     <rename.offset>org.apache.hbase.thirdparty</rename.offset>
     <protobuf.version>4.28.2</protobuf.version>
-    <netty.version>4.1.113.Final</netty.version>
-    <netty.tcnative.version>2.0.66.Final</netty.tcnative.version>
-    <guava.version>33.3.0-jre</guava.version>
+    <netty.version>4.1.116.Final</netty.version>
+    <netty.tcnative.version>2.0.69.Final</netty.tcnative.version>
+    <guava.version>33.4.0-jre</guava.version>
     <commons-cli.version>1.9.0</commons-cli.version>
     <commons-collections.version>4.4</commons-collections.version>
-    <error_prone_annotations.version>2.32.0</error_prone_annotations.version>
+    <error_prone_annotations.version>2.36.0</error_prone_annotations.version>
     <gson.version>2.11.0</gson.version>
     <jetty.version>9.4.56.v20240826</jetty.version>
     <servlet-api.version>3.1.0</servlet-api.version>
-    <jersey.version>2.45</jersey.version>
+    <jersey.version>2.46</jersey.version>
     <jakarta.inject.version>2.6.1</jakarta.inject.version>
     <jakarta.ws.rs-api.version>2.1.6</jakarta.ws.rs-api.version>
     <jakarta.annotation-api.version>1.3.5</jakarta.annotation-api.version>
     <jakarta.validation-api.version>2.0.2</jakarta.validation-api.version>
     <javassist.version>3.30.2-GA</javassist.version>
-    <jackson-jaxrs-json-provider.version>2.17.2</jackson-jaxrs-json-provider.version>
+    <jackson-jaxrs-json-provider.version>2.17.3</jackson-jaxrs-json-provider.version>
   </properties>
   <build>
     <pluginManagement>


### PR DESCRIPTION
…-4.1.10 release
* netty 4.1.113.Final -> 4.1.116.Final
* netty.tcnative 2.0.66.Final -> 2.0.69.Final
* guava 33.3.0-jre -> 33.4.0-jre
* error_prone_annotations 2.32.0 -> 2.36.0
* jersey 2.45 -> 2.46
* jackson-jaxrs-json-provider 2.17.2 -> 2.17.3