### PR TITLE
HBASE-28885 [hbase-thirdparty] Bump hbase.stable.version to 2.5.10 in…

### DIFF
--- a/hbase-noop-htrace/pom.xml
+++ b/hbase-noop-htrace/pom.xml
@@ -36,9 +36,10 @@
     <!-- This library is meant to work with whatever HBase and Hadoop combos we still list
          as recommended. The version here is what we'll test out of the box if you run mvn test
       -->
-    <hbase.stable.version>2.4.17</hbase.stable.version>
+    <hbase.stable.version>2.5.11</hbase.stable.version>
     <!-- should match the slf4j-api version used in the above hbase -->
     <slf4j.version>1.7.33</slf4j.version>
+    <log4j2.version>2.17.2</log4j2.version>
     <!-- These maybe need to match the main repo -->
     <maven.checkstyle.version>3.1.0</maven.checkstyle.version>
     <checkstyle.version>8.29</checkstyle.version>
@@ -68,8 +69,20 @@
     <!-- TODO why does hbase-shaded testing-util need this but not declare it? -->
     <dependency>
       <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
+      <artifactId>slf4j-api</artifactId>
       <version>${slf4j.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j-impl</artifactId>
+      <version>${log4j2.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-1.2-api</artifactId>
+      <version>${log4j2.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/hbase-noop-htrace/src/test/resources/log4j2.properties
+++ b/hbase-noop-htrace/src/test/resources/log4j2.properties
@@ -1,0 +1,137 @@
+#/**
+# * Licensed to the Apache Software Foundation (ASF) under one
+# * or more contributor license agreements.  See the NOTICE file
+# * distributed with this work for additional information
+# * regarding copyright ownership.  The ASF licenses this file
+# * to you under the Apache License, Version 2.0 (the
+# * "License"); you may not use this file except in compliance
+# * with the License.  You may obtain a copy of the License at
+# *
+# *     http://www.apache.org/licenses/LICENSE-2.0
+# *
+# * Unless required by applicable law or agreed to in writing, software
+# * distributed under the License is distributed on an "AS IS" BASIS,
+# * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# * See the License for the specific language governing permissions and
+# * limitations under the License.
+# */
+
+status = warn
+dest = err
+name = PropertiesConfig
+
+# Console appender
+appender.console.type = Console
+appender.console.target = SYSTEM_ERR
+appender.console.name = console
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %d{ISO8601} %-5p [%t] %c{2}: %.1000m%n
+
+# Daily Rolling File Appender
+appender.DRFA.type = RollingFile
+appender.DRFA.name = DRFA
+appender.DRFA.fileName = ${sys:hbase.log.dir:-.}/${sys:hbase.log.file:-hbase.log}
+appender.DRFA.filePattern = ${sys:hbase.log.dir:-.}/${sys:hbase.log.file:-hbase.log}.%d{yyyy-MM-dd}
+appender.DRFA.createOnDemand = true
+appender.DRFA.layout.type = PatternLayout
+appender.DRFA.layout.pattern = %d{ISO8601} %-5p [%t] %c{2}: %.1000m%n
+appender.DRFA.policies.type = Policies
+appender.DRFA.policies.time.type = TimeBasedTriggeringPolicy
+appender.DRFA.policies.time.interval = 1
+appender.DRFA.policies.time.modulate = true
+appender.DRFA.policies.size.type = SizeBasedTriggeringPolicy
+appender.DRFA.policies.size.size = ${sys:hbase.log.maxfilesize:-256MB}
+appender.DRFA.strategy.type = DefaultRolloverStrategy
+appender.DRFA.strategy.max = ${sys:hbase.log.maxbackupindex:-20}
+
+# Rolling File Appender
+appender.RFA.type = RollingFile
+appender.RFA.name = RFA
+appender.RFA.fileName = ${sys:hbase.log.dir:-.}/${sys:hbase.log.file:-hbase.log}
+appender.RFA.filePattern = ${sys:hbase.log.dir:-.}/${sys:hbase.log.file:-hbase.log}.%i
+appender.RFA.createOnDemand = true
+appender.RFA.layout.type = PatternLayout
+appender.RFA.layout.pattern = %d{ISO8601} %-5p [%t] %c{2}: %.1000m%n
+appender.RFA.policies.type = Policies
+appender.RFA.policies.size.type = SizeBasedTriggeringPolicy
+appender.RFA.policies.size.size = ${sys:hbase.log.maxfilesize:-256MB}
+appender.RFA.strategy.type = DefaultRolloverStrategy
+appender.RFA.strategy.max = ${sys:hbase.log.maxbackupindex:-20}
+
+# Security Audit Appender
+appender.RFAS.type = RollingFile
+appender.RFAS.name = RFAS
+appender.RFAS.fileName = ${sys:hbase.log.dir:-.}/${sys:hbase.security.log.file:-SecurityAuth.audit}
+appender.RFAS.filePattern = ${sys:hbase.log.dir:-.}/${sys:hbase.security.log.file:-SecurityAuth.audit}.%i
+appender.RFAS.createOnDemand = true
+appender.RFAS.layout.type = PatternLayout
+appender.RFAS.layout.pattern = %d{ISO8601} %-5p [%t] %c{2}: %.1000m%n
+appender.RFAS.policies.type = Policies
+appender.RFAS.policies.size.type = SizeBasedTriggeringPolicy
+appender.RFAS.policies.size.size = ${sys:hbase.security.log.maxfilesize:-256MB}
+appender.RFAS.strategy.type = DefaultRolloverStrategy
+appender.RFAS.strategy.max = ${sys:hbase.security.log.maxbackupindex:-20}
+
+# Http Access Log RFA, uncomment this if you want an http access.log
+# appender.AccessRFA.type = RollingFile
+# appender.AccessRFA.name = AccessRFA
+# appender.AccessRFA.fileName = /var/log/hbase/access.log
+# appender.AccessRFA.filePattern = /var/log/hbase/access.log.%i
+# appender.AccessRFA.createOnDemand = true
+# appender.AccessRFA.layout.type = PatternLayout
+# appender.AccessRFA.layout.pattern = %m%n
+# appender.AccessRFA.policies.type = Policies
+# appender.AccessRFA.policies.size.type = SizeBasedTriggeringPolicy
+# appender.AccessRFA.policies.size.size = 200MB
+# appender.AccessRFA.strategy.type = DefaultRolloverStrategy
+# appender.AccessRFA.strategy.max = 10
+
+# Null Appender
+appender.NullAppender.type = Null
+appender.NullAppender.name = NullAppender
+
+rootLogger = ${sys:hbase.root.logger:-INFO,console}
+
+logger.SecurityLogger.name = SecurityLogger
+logger.SecurityLogger = ${sys:hbase.security.logger:-INFO,console}
+logger.SecurityLogger.additivity = false
+
+# Custom Logging levels
+# logger.zookeeper.name = org.apache.zookeeper
+# logger.zookeeper.level = ERROR
+
+# logger.FSNamesystem.name = org.apache.hadoop.fs.FSNamesystem
+# logger.FSNamesystem.level = DEBUG
+
+# logger.hbase.name = org.apache.hadoop.hbase
+# logger.hbase.level = DEBUG
+
+# logger.META.name = org.apache.hadoop.hbase.META
+# logger.META.level = DEBUG
+
+# Make these two classes below DEBUG to see more zk debug.
+# logger.ZKUtil.name = org.apache.hadoop.hbase.zookeeper.ZKUtil
+# logger.ZKUtil.level = DEBUG
+
+# logger.ZKWatcher.name = org.apache.hadoop.hbase.zookeeper.ZKWatcher
+# logger.ZKWatcher.level = DEBUG
+
+# logger.dfs.name = org.apache.hadoop.dfs
+# logger.dfs.level = DEBUG
+
+# Prevent metrics subsystem start/stop messages (HBASE-17722)
+logger.MetricsConfig.name = org.apache.hadoop.metrics2.impl.MetricsConfig
+logger.MetricsConfig.level = WARN
+
+logger.MetricsSinkAdapte.name = org.apache.hadoop.metrics2.impl.MetricsSinkAdapter
+logger.MetricsSinkAdapte.level = WARN
+
+logger.MetricsSystemImpl.name = org.apache.hadoop.metrics2.impl.MetricsSystemImpl
+logger.MetricsSystemImpl.level = WARN
+
+# Disable request log by default, you can enable this by changing the appender
+logger.http.name = http.requests
+logger.http.additivity = false
+logger.http = INFO,NullAppender
+# Replace the above with this configuration if you want an http access.log
+# logger.http = INFO,AccessRFA


### PR DESCRIPTION
… hbase-noop-htrace
* Also move to log4j2 to remove transitive dependency `log4j:log4j`