### PR TITLE
HBASE-29304 [hbase-thirdparty] Bump dependency versions before releasing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,15 +133,15 @@
     <os.maven.version>1.7.1</os.maven.version>
     <rename.offset>org.apache.hbase.thirdparty</rename.offset>
     <protobuf.version>4.29.2</protobuf.version>
-    <netty.version>4.1.119.Final</netty.version>
-    <netty.tcnative.version>2.0.69.Final</netty.tcnative.version>
-    <guava.version>33.4.0-jre</guava.version>
+    <netty.version>4.1.121.Final</netty.version>
+    <netty.tcnative.version>2.0.71.Final</netty.tcnative.version>
+    <guava.version>33.4.8-jre</guava.version>
     <commons-cli.version>1.9.0</commons-cli.version>
     <commons-collections.version>4.4</commons-collections.version>
-    <error_prone_annotations.version>2.36.0</error_prone_annotations.version>
-    <gson.version>2.11.0</gson.version>
-    <jetty.version>9.4.56.v20240826</jetty.version>
-    <jetty-12-plus.version>12.0.20</jetty-12-plus.version>
+    <error_prone_annotations.version>2.38.0</error_prone_annotations.version>
+    <gson.version>2.13.1</gson.version>
+    <jetty.version>9.4.57.v20241219</jetty.version>
+    <jetty-12-plus.version>12.0.21</jetty-12-plus.version>
     <servlet-api.version>3.1.0</servlet-api.version>
     <jersey.version>2.46</jersey.version>
     <jakarta.inject.version>2.6.1</jakarta.inject.version>
@@ -149,7 +149,7 @@
     <jakarta.annotation-api.version>1.3.5</jakarta.annotation-api.version>
     <jakarta.validation-api.version>2.0.2</jakarta.validation-api.version>
     <javassist.version>3.30.2-GA</javassist.version>
-    <jackson-jaxrs-json-provider.version>2.17.3</jackson-jaxrs-json-provider.version>
+    <jackson-jaxrs-json-provider.version>2.19.0</jackson-jaxrs-json-provider.version>
     <spotless.version>2.30.0</spotless.version>
   </properties>
   <build>


### PR DESCRIPTION
* netty 4.1.119.Final -> 4.1.121.Final
* netty.tcnative 2.0.69.Final -> 2.0.71.Final
* guava 33.4.0-jre -> 33.4.8-jre
* error_prone_annotations 2.36.0 -> 2.38.0
* gson 2.11.0 -> 2.13.1
* jetty 9.4.56.v20240826 -> 9.4.57.v20241219
* jetty-12-plus 12.0.20 -> 12.0.21
* jackson-jaxrs-json-provider 2.17.3 -> 2.19.0