### PR TITLE
HBASE-29354 Jetty12 dependencies compiled with JDK17 violate hbase-thirdparty bytecode restrictions

### DIFF
--- a/hbase-shaded-jetty-12-plus-core/pom.xml
+++ b/hbase-shaded-jetty-12-plus-core/pom.xml
@@ -127,21 +127,21 @@
         </exclusion>
       </exclusions>
     </dependency>
-  <dependency>
-    <groupId>org.eclipse.jetty</groupId>
-    <artifactId>jetty-ee</artifactId>
-    <version>${jetty-12-plus.version}</version>
-    <exclusions>
-      <exclusion>
-        <groupId>org.slf4j</groupId>
-        <artifactId>slf4j-api</artifactId>
-      </exclusion>
-    </exclusions>
-  </dependency>
     <dependency>
-    <groupId>org.eclipse.jetty</groupId>
-    <artifactId>jetty-xml</artifactId>
-    <version>${jetty-12-plus.version}</version>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-ee</artifactId>
+      <version>${jetty-12-plus.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-xml</artifactId>
+      <version>${jetty-12-plus.version}</version>
       <exclusions>
         <exclusion>
           <groupId>org.slf4j</groupId>
@@ -200,7 +200,7 @@
                      produce. See below for how to exclusion of transitive dependencies.
                    -->
                   <exclude>org.slf4j:slf4j-api</exclude>
-                 <!-- On the "next" build, exclude a lingering shaded jar if it exists (user did not `clean`).
+                  <!-- On the "next" build, exclude a lingering shaded jar if it exists (user did not `clean`).
                    Maven will happily pick up the previous shaded jar and try to include that in the N+1th build
                    if we don't exclude it. This will result in a failure in the ServicesResourceTransformer claiming
                    that we've already packaged a services file once. -->
@@ -217,6 +217,23 @@
             </configuration>
           </execution>
         </executions>
+      </plugin>
+      <!-- This module relocates Jetty 12+ EE8 dependencies compiled with JDK 17, hence, overriding the project-level
+      restriction on maxJdkVersion of 'compileSource'! See HBASE-29354-->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <configuration>
+          <rules>
+            <enforceBytecodeVersion>
+              <maxJdkVersion>17</maxJdkVersion>
+              <ignoreOptionals>true</ignoreOptionals>
+              <ignoredScopes>
+                <ignoredScope>test</ignoredScope>
+              </ignoredScopes>
+            </enforceBytecodeVersion>
+          </rules>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/hbase-shaded-jetty-12-plus-ee8/pom.xml
+++ b/hbase-shaded-jetty-12-plus-ee8/pom.xml
@@ -247,6 +247,23 @@
           </execution>
         </executions>
       </plugin>
+      <!-- This module relocates Jetty 12+ EE8 dependencies compiled with JDK 17, hence, overriding the project-level
+      restriction on maxJdkVersion of 'compileSource'! See HBASE-29354-->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <configuration>
+          <rules>
+            <enforceBytecodeVersion>
+              <maxJdkVersion>17</maxJdkVersion>
+              <ignoreOptionals>true</ignoreOptionals>
+              <ignoredScopes>
+                <ignoredScope>test</ignoredScope>
+              </ignoredScopes>
+            </enforceBytecodeVersion>
+          </rules>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
* Override the `maxJdkVersion` to 17 in the jetty12 related modules
* Unrelated: Fix spotless issue for existing changes