### PR TITLE
HBASE-29488 [hbase-thirdparty] Bump dependency versions before releasing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,23 +137,23 @@
     <os.maven.version>1.7.1</os.maven.version>
     <rename.offset>org.apache.hbase.thirdparty</rename.offset>
     <protobuf.version>4.30.2</protobuf.version>
-    <netty.version>4.1.121.Final</netty.version>
-    <netty.tcnative.version>2.0.71.Final</netty.tcnative.version>
+    <netty.version>4.1.123.Final</netty.version>
+    <netty.tcnative.version>2.0.72.Final</netty.tcnative.version>
     <guava.version>33.4.8-jre</guava.version>
     <commons-cli.version>1.9.0</commons-cli.version>
     <commons-collections.version>4.4</commons-collections.version>
-    <error_prone_annotations.version>2.38.0</error_prone_annotations.version>
+    <error_prone_annotations.version>2.41.0</error_prone_annotations.version>
     <gson.version>2.13.1</gson.version>
     <jetty.version>9.4.57.v20241219</jetty.version>
-    <jetty-12-plus.version>12.0.22</jetty-12-plus.version>
+    <jetty-12-plus.version>12.0.23</jetty-12-plus.version>
     <servlet-api.version>3.1.0</servlet-api.version>
-    <jersey.version>2.46</jersey.version>
+    <jersey.version>2.47</jersey.version>
     <jakarta.inject.version>2.6.1</jakarta.inject.version>
     <jakarta.ws.rs-api.version>2.1.6</jakarta.ws.rs-api.version>
     <jakarta.annotation-api.version>1.3.5</jakarta.annotation-api.version>
     <jakarta.validation-api.version>2.0.2</jakarta.validation-api.version>
     <javassist.version>3.30.2-GA</javassist.version>
-    <jackson-jaxrs-json-provider.version>2.19.0</jackson-jaxrs-json-provider.version>
+    <jackson-jaxrs-json-provider.version>2.19.2</jackson-jaxrs-json-provider.version>
     <spotless.version>2.30.0</spotless.version>
 
     <!-- Below is copied from hbase project -->


### PR DESCRIPTION
* netty 4.1.121.Final -> 4.1.123.Final
* netty.tcnative 2.0.71.Final -> 2.0.72.Final
* error_prone_annotations 2.38.0 -> 2.41.0
* jetty-12-plus 12.0.22 -> 12.0.23
* jersey 2.46 -> 2.47
* jackson-jaxrs-json-provider 2.19.0 -> 2.19.2
