### PR TITLE
HBASE-30278 [INFRA] Set up default rulesets for default and release branches

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -31,12 +31,25 @@ github:
     issues: false
     projects: false
   enabled_merge_buttons:
-    squash:  true
-    merge:   false
-    rebase:  true
+    squash: true
+    merge: false
+    rebase: true
   autolink_jira: HBASE
+  rulesets:
+    - name: "Default Branch Protection"
+      type: branch
+      branches:
+        includes:
+          - "~DEFAULT_BRANCH"
+          - "release/*"
+          - "rel/*"
+        excludes: []
+      bypass_teams:
+        - root
+      restrict_deletion: true
+      restrict_force_push: true
 notifications:
-  commits:      commits@hbase.apache.org
-  issues:       issues@hbase.apache.org
+  commits: commits@hbase.apache.org
+  issues: issues@hbase.apache.org
   pullrequests: issues@hbase.apache.org
   jira_options: link label

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -41,7 +41,6 @@ github:
       branches:
         includes:
           - "~DEFAULT_BRANCH"
-          - "branch-*"
           - "rel/*"
         excludes: []
       bypass_teams:

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -41,7 +41,7 @@ github:
       branches:
         includes:
           - "~DEFAULT_BRANCH"
-          - "release/*"
+          - "branch-*"
           - "rel/*"
         excludes: []
       bypass_teams:


### PR DESCRIPTION
This Pull Request enables the repository to conform with the "sane default security settings" of the Apache Software Foundation by configuring a default branch ruleset that protects the default branch and any release branches.

Note that `~DEFAULT_BRANCH` is a GitHub symbolic link to the current default branch (HEAD) of the repository and does not need changing.
If the managing project does not wish to set up these defaults, please close this Pull Request. Alternatively, the project may merge this Pull Request to apply the changes immediately.

If no action is taken, this Pull Request will be automatically merged by the Apache Infrastructure team on **2026-06-14** (30 days from now).

For any further information, please reach us on Slack or at: users@infra.apache.org
